### PR TITLE
Fixed multiple infinite loop cases, converted files to Tonel v3.0

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -7,6 +7,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -16,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ pharo9, pharo10, pharo11, pharo12 ]
+        smalltalk: [ pharo9, pharo10, pharo11, pharo12, pharo13, pharo14 ]
         group: [ default ]
         tests: [ Roassal-Layouts ]
         os: [ ubuntu-latest ]
@@ -27,20 +28,20 @@ jobs:
     steps:
         
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       # depth 0 will download all the repository history
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       
       # This will delete roassal and numeric scales and it executes the tests again
       - name: Run pharo Tests
         id: tests
-        uses: akevalion/PharoTestsAction@v1
+        uses: tinchodias/PharoTestsAction@v3
         with:
           removes-repo: 'Roassal, RoassalLayouts, Numeric'
           baseline: 'RoassalLayouts'

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![CI](https://github.com/pharo-graphics/RoassalLayouts/actions/workflows/runTests.yml/badge.svg)](https://github.com/pharo-graphics/RoassalLayouts/actions/workflows/runTests.yml)
 ![Discord](https://img.shields.io/discord/223421264751099906)
 
-[![Pharo 8](https://img.shields.io/badge/Pharo-8.0-%23aac9ff.svg)](https://pharo.org/download)
 [![Pharo 9](https://img.shields.io/badge/Pharo-9.0-%23aac9ff.svg)](https://pharo.org/download)
 [![Pharo 10](https://img.shields.io/badge/Pharo-10-%23aac9ff.svg)](https://pharo.org/download)
 [![Pharo 11](https://img.shields.io/badge/Pharo-11-%23aac9ff.svg)](https://pharo.org/download)
 [![Pharo 12](https://img.shields.io/badge/Pharo-12-%23aac9ff.svg)](https://pharo.org/download)
+[![Pharo 13](https://img.shields.io/badge/Pharo-13-%23aac9ff.svg)](https://pharo.org/download)
 
 [*Chat with us on #Roassal*](https://discord.gg/QewZMZa)
 

--- a/src/BaselineOfRoassalLayouts/BaselineOfRoassalLayouts.class.st
+++ b/src/BaselineOfRoassalLayouts/BaselineOfRoassalLayouts.class.st
@@ -3,12 +3,13 @@ Based on roassal
 https://github.com/ObjectProfile/Roassal3
 "
 Class {
-	#name : #BaselineOfRoassalLayouts,
-	#superclass : #BaselineOf,
-	#category : #BaselineOfRoassalLayouts
+	#name : 'BaselineOfRoassalLayouts',
+	#superclass : 'BaselineOf',
+	#category : 'BaselineOfRoassalLayouts',
+	#package : 'BaselineOfRoassalLayouts'
 }
 
-{ #category : #baselines }
+{ #category : 'baselines' }
 BaselineOfRoassalLayouts >> baseline: spec [
 	<baseline>
 	spec for: #common do: [

--- a/src/BaselineOfRoassalLayouts/package.st
+++ b/src/BaselineOfRoassalLayouts/package.st
@@ -1,1 +1,1 @@
-Package { #name : #BaselineOfRoassalLayouts }
+Package { #name : 'BaselineOfRoassalLayouts' }

--- a/src/Roassal-Layouts-Tests/ManifestRoassalLayoutsTests.class.st
+++ b/src/Roassal-Layouts-Tests/ManifestRoassalLayoutsTests.class.st
@@ -2,7 +2,9 @@
 Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestRoassalLayoutsTests,
-	#superclass : #PackageManifest,
-	#category : 'Roassal-Layouts-Tests-Manifest'
+	#name : 'ManifestRoassalLayoutsTests',
+	#superclass : 'PackageManifest',
+	#category : 'Roassal-Layouts-Tests-Manifest',
+	#package : 'Roassal-Layouts-Tests',
+	#tag : 'Manifest'
 }

--- a/src/Roassal-Layouts-Tests/RSAlignmentTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSAlignmentTest.class.st
@@ -1,19 +1,20 @@
 Class {
-	#name : #RSAlignmentTest,
-	#superclass : #TestCase,
+	#name : 'RSAlignmentTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'align'
 	],
-	#category : 'Roassal-Layouts-Tests'
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSAlignmentTest >> setUp [
 	super setUp.
 	align := RSAlignment new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testCenter [
 	| es |
 	es := (1 to: 5) collect: [ :v | RSLayoutNode new size: 10 ] as: RSGroup.
@@ -23,7 +24,7 @@ RSAlignmentTest >> testCenter [
 	self assert: es encompassingRectangle equals: ((0.0@0.0) corner: (70.0@10.0))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromBottom [
 	| es |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -36,7 +37,7 @@ RSAlignmentTest >> testFromBottom [
 	self assert: (es collect: [ :e | e encompassingRectangle bottom ]) asArray equals: #(170.0 170.0 170.0 170.0 170.0 170.0 170.0 170.0 170.0 170.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromLeft [
 	| es |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -49,7 +50,7 @@ RSAlignmentTest >> testFromLeft [
 	self assert: (es collect: [ :e | e encompassingRectangle left ]) asArray equals: #(-150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromLeftWithAFixShape [
 	| es |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -61,7 +62,7 @@ RSAlignmentTest >> testFromLeftWithAFixShape [
 	self assert: (es collect: [ :e | e encompassingRectangle left ]) asArray equals: #(0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromLeftWithFixedShape [
 	| es c |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -79,7 +80,7 @@ RSAlignmentTest >> testFromLeftWithFixedShape [
 	self assert: (es collect: [ :e | e encompassingRectangle left ]) asArray equals: #(-150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0 -150.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromRight [
 	| es |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -92,7 +93,7 @@ RSAlignmentTest >> testFromRight [
 	self assert: (es collect: [ :e | e encompassingRectangle right ]) asArray equals: #(170.0 170.0 170.0 170.0 170.0 170.0 170.0 170.0 170.0 170.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromTop [
 	| es |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -105,7 +106,7 @@ RSAlignmentTest >> testFromTop [
 	self assert: (es collect: [ :e | e encompassingRectangle top ]) asArray equals: #(-50.0 -50.0 -50.0 -50.0 -50.0 -50.0 -50.0 -50.0 -50.0 -50.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testFromTopWithAFixShape [
 	| es |
 	es := (10 to: 100 by: 10) collect: [ :n | RSLayoutNode new size: n; yourself ].
@@ -120,7 +121,7 @@ RSAlignmentTest >> testFromTopWithAFixShape [
 	self assert: (es collect: [ :e | e encompassingRectangle top ]) asArray equals: #(0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testHasElement [
 	self deny: align hasShape.
 	align shapes: (Array with: RSLayoutNode new).
@@ -129,7 +130,7 @@ RSAlignmentTest >> testHasElement [
 	self deny: align hasShape
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAlignmentTest >> testNoErrorOnDefault [
 
 	RSAlignment new left; right; top; bottom

--- a/src/Roassal-Layouts-Tests/RSAngleLineLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSAngleLineLayoutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSAngleLineLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSAngleLineLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAngleLineLayoutTest >> testBasic [
 
 	| layout angle |
@@ -15,7 +16,7 @@ RSAngleLineLayoutTest >> testBasic [
 	self assert: layout angle equals: angle
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAngleLineLayoutTest >> testGapSize [
 
 	| layout var1st var2nd |
@@ -27,7 +28,7 @@ RSAngleLineLayoutTest >> testGapSize [
 	self assert: var2nd position closeTo: 107.5 @ 2.5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAngleLineLayoutTest >> testLayoutWith0Angle [
 
 	| layout x gap |
@@ -40,7 +41,7 @@ RSAngleLineLayoutTest >> testLayoutWith0Angle [
 		x := x + each width + gap ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAngleLineLayoutTest >> testLayoutWith90Angle [
 
 	| layout y gap |
@@ -54,7 +55,7 @@ RSAngleLineLayoutTest >> testLayoutWith90Angle [
 		y := y + each height + gap ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAngleLineLayoutTest >> testLayoutWithThreeElements [
 	| layout gap extent |
 	layout := RSAngleLineLayout new.

--- a/src/Roassal-Layouts-Tests/RSAngleLineLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSAngleLineLayoutTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSAngleLineLayoutTest >> apply [
+
+	RSAngleLineLayout new on: shapes
+]
+
 { #category : 'tests' }
 RSAngleLineLayoutTest >> testBasic [
 

--- a/src/Roassal-Layouts-Tests/RSCircularAroundAVertexLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSCircularAroundAVertexLayoutTest.class.st
@@ -8,6 +8,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSCircularAroundAVertexLayoutTest >> apply [
+
+	RSCircularAroundAVertexLayout new on: canvas nodes
+]
+
 { #category : 'tests' }
 RSCircularAroundAVertexLayoutTest >> testApplyDefaultLayoutOverlapsShapes [
 	| layout first second |

--- a/src/Roassal-Layouts-Tests/RSCircularAroundAVertexLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSCircularAroundAVertexLayoutTest.class.st
@@ -2,12 +2,13 @@
 A RSCircularAroundAVertexLayoutTest is a test class for testing the behavior of RSCircularAroundAVertexLayout
 "
 Class {
-	#name : #RSCircularAroundAVertexLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSCircularAroundAVertexLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircularAroundAVertexLayoutTest >> testApplyDefaultLayoutOverlapsShapes [
 	| layout first second |
 	layout := RSCircularAroundAVertexLayout new.
@@ -18,7 +19,7 @@ RSCircularAroundAVertexLayoutTest >> testApplyDefaultLayoutOverlapsShapes [
 	self deny: first position equals: second position
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircularAroundAVertexLayoutTest >> testApplyLayoutShouldChangeOldPositions [
 	| layout oldPositions |
 	layout := RSCircularAroundAVertexLayout new.
@@ -27,7 +28,7 @@ RSCircularAroundAVertexLayoutTest >> testApplyLayoutShouldChangeOldPositions [
 	self deny: (canvas nodes collect: #position) equals: oldPositions
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircularAroundAVertexLayoutTest >> testRadius [
 	| layout boundingBox |
 	layout := RSCircularAroundAVertexLayout new.

--- a/src/Roassal-Layouts-Tests/RSClusteringLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSClusteringLayoutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSClusteringLayoutTest,
-	#superclass : #RSLayoutTestCase,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSClusteringLayoutTest',
+	#superclass : 'RSLayoutTestCase',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSClusteringLayoutTest >> testBasic [
 
 	| c shapes lb nodes |
@@ -70,7 +71,7 @@ RSClusteringLayoutTest >> testBasic [
 144 @ 65.}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSClusteringLayoutTest >> testBasic2 [
 
 	| shapes c lb nodes clusters |
@@ -90,7 +91,7 @@ RSClusteringLayoutTest >> testBasic2 [
 	self assert: clusters size equals: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSClusteringLayoutTest >> testBasic3 [
 
 	| c shapes lb nodes clusters |
@@ -110,7 +111,7 @@ RSClusteringLayoutTest >> testBasic3 [
 	self assert: clusters size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSClusteringLayoutTest >> testCycles [
 	| chars canvas shapes |
 	canvas := RSLayoutNode new.

--- a/src/Roassal-Layouts-Tests/RSDominanceTreeLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSDominanceTreeLayoutTest.class.st
@@ -1,0 +1,15 @@
+"
+A RSDominanceTreeLayoutTest is a test class for testing the behavior of RSDominanceTreeLayout
+"
+Class {
+	#name : 'RSDominanceTreeLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
+}
+
+{ #category : 'utilities' }
+RSDominanceTreeLayoutTest >> apply [
+
+	RSDominanceTreeLayout new on: shapes
+]

--- a/src/Roassal-Layouts-Tests/RSFlowLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSFlowLayoutTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSFlowLayoutTest >> apply [
+
+	RSFlowLayout new on: shapes
+]
+
 { #category : 'tests' }
 RSFlowLayoutTest >> testLinesEven [
 	| layout lines line n |

--- a/src/Roassal-Layouts-Tests/RSFlowLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSFlowLayoutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSFlowLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSFlowLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSFlowLayoutTest >> testLinesEven [
 	| layout lines line n |
 	layout := RSFlowLayout new.
@@ -20,7 +21,7 @@ RSFlowLayoutTest >> testLinesEven [
 		equals: (layout gapSize* n)+(shapes first height * (n-1.5))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSFlowLayoutTest >> testLinesOdd [
 	| layout lines line n |
 	layout := RSFlowLayout new.

--- a/src/Roassal-Layouts-Tests/RSGridLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSGridLayoutTest.class.st
@@ -1,24 +1,25 @@
 Class {
-	#name : #RSGridLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSGridLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSGridLayoutTest >> testBasicCustomizedGapSizeGridLayout [
 
 	RSGridLayout new gapSize:15; on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(2.5@2.5). (22.5@2.5). (42.5@2.5). (62.5@2.5). (2.5@22.5). (22.5@22.5). (42.5@22.5). (62.5@22.5). (2.5@42.5). (22.5@42.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSGridLayoutTest >> testBasicDefaultGapSizeGridLayout [
 
 	RSGridLayout new gapSize:5; on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(2.5@2.5). (12.5@2.5). (22.5@2.5). (32.5@2.5). (2.5@12.5). (12.5@12.5). (22.5@12.5). (32.5@12.5). (2.5@22.5). (12.5@22.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSGridLayoutTest >> testFixedPositionsAfterApplyingTheLayout [
 
 	RSGridLayout on: canvas nodes.
@@ -34,7 +35,7 @@ RSGridLayoutTest >> testFixedPositionsAfterApplyingTheLayout [
 12 @ 22}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSGridLayoutTest >> testLineItemsCount [
 
 	| shapesInLine |
@@ -45,7 +46,7 @@ RSGridLayoutTest >> testLineItemsCount [
 	self assert: (shapesInLine allSatisfy: [:group | group size between: 1 and: 3 ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSGridLayoutTest >> testLineItemsCountForASingleLineOfShapes [
 	canvas := RSLayoutNode new.
 	shapes := (1 to: 3) collect: [ :each | RSLayoutNode new size: 20 ].

--- a/src/Roassal-Layouts-Tests/RSGridLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSGridLayoutTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSGridLayoutTest >> apply [
+
+	RSGridLayout new on: canvas nodes
+]
+
 { #category : 'tests' }
 RSGridLayoutTest >> testBasicCustomizedGapSizeGridLayout [
 

--- a/src/Roassal-Layouts-Tests/RSHorizontalDominanceTreeLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSHorizontalDominanceTreeLayoutTest.class.st
@@ -1,0 +1,15 @@
+"
+A RSHorizontalDominanceTreeLayoutTest is a test class for testing the behavior of RSHorizontalDominanceTreeLayout
+"
+Class {
+	#name : 'RSHorizontalDominanceTreeLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
+}
+
+{ #category : 'utilities' }
+RSHorizontalDominanceTreeLayoutTest >> apply [
+
+	RSHorizontalDominanceTreeLayout new on: shapes
+]

--- a/src/Roassal-Layouts-Tests/RSHorizontalTreeLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSHorizontalTreeLayoutTest.class.st
@@ -1,22 +1,23 @@
 Class {
-	#name : #RSHorizontalTreeLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSHorizontalTreeLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testBasic [
 	RSHorizontalTreeLayout on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(7.5@23.5). (32.5@15.5). (32.5@35.5). (57.5@11.5). (57.5@23.5). (57.5@31.5). (57.5@39.5). (82.5@7.5). (82.5@15.5). (82.5@23.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testBasicWithHorizontalGap [
 	RSHorizontalTreeLayout new horizontalGap: 50; on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(7.5@23.5). (62.5@15.5). (62.5@35.5). (117.5@11.5). (117.5@23.5). (117.5@31.5). (117.5@39.5). (172.5@7.5). (172.5@15.5). (172.5@23.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testBasicWithLeftGap [
 	| withNoGap withGap |
 	RSHorizontalTreeLayout new leftGap: 15; on: canvas nodes.
@@ -25,7 +26,7 @@ RSHorizontalTreeLayoutTest >> testBasicWithLeftGap [
 	self assert: (shapes collect: #position) asArray equals: withGap
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testBasicWithTopGap [
 	| withNoGap withGap |
 	RSHorizontalTreeLayout new topGap: 15; on: canvas nodes.
@@ -34,13 +35,13 @@ RSHorizontalTreeLayoutTest >> testBasicWithTopGap [
 	self assert: (shapes collect: #position) asArray equals: withGap
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testBasicWithVerticalGap [
 	RSHorizontalTreeLayout new verticalGap: 50; on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(7.5@117.5). (32.5@62.5). (32.5@200.0). (57.5@35.0). (57.5@117.5). (57.5@172.5). (57.5@227.5). (82.5@7.5). (82.5@62.5). (82.5@117.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testCycles [
 	| chars |
 	canvas := RSLayoutNode new.

--- a/src/Roassal-Layouts-Tests/RSHorizontalTreeLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSHorizontalTreeLayoutTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSHorizontalTreeLayoutTest >> apply [
+
+	RSHorizontalTreeLayout on: canvas nodes
+]
+
 { #category : 'tests' }
 RSHorizontalTreeLayoutTest >> testBasic [
 	RSHorizontalTreeLayout on: canvas nodes.

--- a/src/Roassal-Layouts-Tests/RSLayoutBuilderTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSLayoutBuilderTest.class.st
@@ -1,30 +1,31 @@
 Class {
-	#name : #RSLayoutBuilderTest,
-	#superclass : #TestCase,
+	#name : 'RSLayoutBuilderTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'builder'
 	],
-	#category : 'Roassal-Layouts-Tests'
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSLayoutBuilderTest >> setUp [
 	super setUp.
 	builder := RSLayoutBuilder new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLayoutBuilderTest >> testConditionalLayout [
 	builder ifConnected: RSTreeLayout new ifNotConnected: RSFlowLayout new.
 	self assert: builder layout class equals: RSConditionalLayout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLayoutBuilderTest >> testDefaultLayoutClass [
 	self assert: builder layout class equals: RSFlowLayout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLayoutBuilderTest >> testSelectNoneLayout [
 	| shapes |
 	shapes := RSLayoutNode models: (1 to: 10).
@@ -34,7 +35,7 @@ RSLayoutBuilderTest >> testSelectNoneLayout [
 	self assert: (shapes allSatisfy: [ :each | each position = (0@0) ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLayoutBuilderTest >> testUseGridCircleTreeChangesSelectedLayout [
 	{#grid -> RSGridLayout.
 	 #circle -> RSCircleLayout.

--- a/src/Roassal-Layouts-Tests/RSLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSLayoutTest.class.st
@@ -14,6 +14,12 @@ RSLayoutTest class >> isAbstract [
 	^ self ==  RSLayoutTest
 ]
 
+{ #category : 'utilities' }
+RSLayoutTest >> apply [
+
+	self subclassResponsibility
+]
+
 { #category : 'running' }
 RSLayoutTest >> setUp [
 	| eb |
@@ -30,4 +36,30 @@ RSLayoutTest >> setUp [
 	eb canvas: canvas.
 	eb shapes: shapes.
 	eb connectFrom: [ :nb | nb // 2 ]
+]
+
+{ #category : 'utilities' }
+RSLayoutTest >> setUpGraphWithCycles [
+
+	canvas := RSLayoutNode new.
+	shapes := (1 to: 4) collect: [ :i |
+			          (RSLayoutNode model: i)
+				          size: 5;
+				          yourself ].
+	shapes first size: 200. "this tests specific infinite loop bug in tree layout"
+	canvas addAll: shapes.
+	RSLayoutLineBuilder new
+		canvas: canvas;
+		useAssociations: {
+				(1 -> 2).
+				(2 -> 3).
+				(3 -> 4).
+				(4 -> 2) } "cycle"
+]
+
+{ #category : 'tests' }
+RSLayoutTest >> testLoop [
+
+	self setUpGraphWithCycles.
+	self apply
 ]

--- a/src/Roassal-Layouts-Tests/RSLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSLayoutTest.class.st
@@ -1,19 +1,20 @@
 Class {
-	#name : #RSLayoutTest,
-	#superclass : #RSLayoutTestCase,
+	#name : 'RSLayoutTest',
+	#superclass : 'RSLayoutTestCase',
 	#instVars : [
 		'shapes',
 		'canvas'
 	],
-	#category : 'Roassal-Layouts-Tests'
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RSLayoutTest class >> isAbstract [
 	^ self ==  RSLayoutTest
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RSLayoutTest >> setUp [
 	| eb |
 	super setUp.

--- a/src/Roassal-Layouts-Tests/RSLayoutTestCase.class.st
+++ b/src/Roassal-Layouts-Tests/RSLayoutTestCase.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSLayoutTestCase,
-	#superclass : #TestCase,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSLayoutTestCase',
+	#superclass : 'TestCase',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 RSLayoutTestCase >> assertIntegerPosition: aGroupOfShapes equals: anArray [
 	| col |
 	col := aGroupOfShapes collect: [ :each | each position asIntegerPoint ] as: Array.

--- a/src/Roassal-Layouts-Tests/RSLocationTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSLocationTest.class.st
@@ -1,15 +1,16 @@
 Class {
-	#name : #RSLocationTest,
-	#superclass : #TestCase,
+	#name : 'RSLocationTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'shape',
 		'target',
 		'canvas'
 	],
-	#category : 'Roassal-Layouts-Tests'
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSLocationTest >> setUp [
 	super setUp.
 
@@ -20,20 +21,20 @@ RSLocationTest >> setUp [
 	canvas add: target; add: shape
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testAbove [
 	RSLocation new above; move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: 0 @ -15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testAboveRectangle [
 	RSLocation new above; move: shape on: (0 asPoint corner: 50 asPoint).
 	self assert: shape position equals: 25 @ -5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testBasic [
 	| location |
 	location := RSLocation new.
@@ -48,7 +49,7 @@ RSLocationTest >> testBasic [
 	self assert: shape position equals: 0 asPoint
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testBelow [
 
 	RSLocation new below ; move: shape on: target.
@@ -57,7 +58,7 @@ RSLocationTest >> testBelow [
 	self assert: shape position equals: 0 @ 15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testInComposite [
 	| composite |
 	canvas := RSLayoutNode new.
@@ -75,7 +76,7 @@ RSLocationTest >> testInComposite [
 	self assert: shape position equals: 0@0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testInComposite2 [
 	| composite |
 	canvas := RSLayoutNode new.
@@ -94,49 +95,49 @@ RSLocationTest >> testInComposite2 [
 	self assert: shape position equals: 10 asPoint + 0 asPoint
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testInnerXInnerY [
 	RSLocation new innerX; innerY; middle; right; move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: 5 @ 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testInnerXOuterY [
 	RSLocation new innerX; outerY; bottom; right; move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: 5 @ 15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testInsideCornerLeft [
 	RSLocation new insideCornerLeft move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: -5 @ -15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testInsideCornerRight [
 	RSLocation new insideCornerRight move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: 5 @ -15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testMiddleLeft [
 	RSLocation new middle; left; outer; move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: -15 @ 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testMiddleLeftInner [
 	RSLocation new middle; left; inner; move: shape on: target.
 	self assert: target position equals: 0 asPoint.
 	self assert: shape position equals: -5 @ 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSLocationTest >> testOutsideXinsideY [
 	RSLocation new outerX; innerY; bottom; right; move: shape on: target.
 	self assert: target position equals: 0 asPoint.

--- a/src/Roassal-Layouts-Tests/RSOvalLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSOvalLayoutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSOvalLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : #'Roassal-Layouts-Tests'
+	#name : 'RSOvalLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSOvalLayoutTest >> testSimple [
 	RSOvalLayout on: canvas nodes.
 

--- a/src/Roassal-Layouts-Tests/RSOvalLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSOvalLayoutTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSOvalLayoutTest >> apply [
+
+	RSOvalLayout on: canvas nodes
+]
+
 { #category : 'tests' }
 RSOvalLayoutTest >> testSimple [
 	RSOvalLayout on: canvas nodes.

--- a/src/Roassal-Layouts-Tests/RSResizeTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSResizeTest.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #RSResizeTest,
-	#superclass : #TestCase,
+	#name : 'RSResizeTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'resize',
 		'shapes'
 	],
-	#category : 'Roassal-Layouts-Tests'
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSResizeTest >> setUp [
 	super setUp.
 	shapes := (1 to: 3) collect: [ :o |
@@ -20,51 +21,51 @@ RSResizeTest >> setUp [
 	resize shapes: shapes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testBiggestExtent [
 	self assert: resize biggestExtent equals: 4 @ 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testBiggestShape [
 	self assert: resize biggestShape equals: shapes last.
 	resize useBiggestShape.
 	self assert: resize fixedShape equals: shapes last
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testHighestShape [
 	self assert: resize highestShape equals: shapes last
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testSameHeight [
 	resize fixedShape: shapes second.
 	resize sameHeight.
 	self assert: (shapes collect: #extent) sorted asArray equals: (Array with: (2.0@2.0) with: (3.0@2.0) with: (4.0@2.0))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testSameSize [
 	resize fixedShape: shapes second.
 	resize sameSize.
 	self assert: (shapes collect: #extent) asSet asArray equals: (Array with: (3.0@2.0))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testSameSizeWithoutFixedShape [
 	resize sameSize.
 	self assert: (shapes collect: #extent) asSet asArray equals: (Array with: (4.0 @ 3.0))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testSameWidth [
 	resize fixedShape: shapes second.
 	resize sameWidth.
 	self assert: (shapes collect: #extent) sorted asArray equals: (Array with: (3.0@1.0) with:(3.0@2.0) with: (3.0@3.0))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSResizeTest >> testWidestShape [
 	self assert: resize widestShape equals: shapes last
 ]

--- a/src/Roassal-Layouts-Tests/RSSugiyamaLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSSugiyamaLayoutTest.class.st
@@ -1,15 +1,16 @@
 Class {
-	#name : #RSSugiyamaLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSSugiyamaLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSSugiyamaLayoutTest >> testBasic [
 	RSSugiyamaLayout on: canvas nodes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSSugiyamaLayoutTest >> testOnCycle [
 	canvas nodes copy do: #remove.
 	canvas addAll: ((1 to: 3) collect:  [ :each | RSLayoutNode new model: each ]).

--- a/src/Roassal-Layouts-Tests/RSSugiyamaLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSSugiyamaLayoutTest.class.st
@@ -5,13 +5,19 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSSugiyamaLayoutTest >> apply [
+
+	self shouldNotImplement
+]
+
 { #category : 'tests' }
 RSSugiyamaLayoutTest >> testBasic [
 	RSSugiyamaLayout on: canvas nodes
 ]
 
 { #category : 'tests' }
-RSSugiyamaLayoutTest >> testOnCycle [
+RSSugiyamaLayoutTest >> testLoop [
 	canvas nodes copy do: #remove.
 	canvas addAll: ((1 to: 3) collect:  [ :each | RSLayoutNode new model: each ]).
 	RSLayoutLineBuilder new

--- a/src/Roassal-Layouts-Tests/RSTreeLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSTreeLayoutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSTreeLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSTreeLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> computeTreeWithCycles [
 	| chars |
 	canvas := RSLayoutNode new.
@@ -35,19 +36,19 @@ RSTreeLayoutTest >> computeTreeWithCycles [
 			$d -> $a}. "cycle"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testBasic [
 	RSTreeLayout on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(23.5@7.5). (15.5@32.5). (35.5@32.5). (11.5@57.5). (23.5@57.5). (31.5@57.5). (39.5@57.5). (7.5@82.5). (15.5@82.5). (23.5@82.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testBasicWithHorizontalGap [
 	RSTreeLayout new horizontalGap: 50; on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(117.5@7.5). (62.5@32.5). (200.0@32.5). (35.0@57.5). (117.5@57.5). (172.5@57.5). (227.5@57.5). (7.5@82.5). (62.5@82.5). (117.5@82.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testBasicWithLeftGap [
 	| withNoGap withGap |
 	RSTreeLayout new leftGap: 15; on: canvas nodes.
@@ -56,7 +57,7 @@ RSTreeLayoutTest >> testBasicWithLeftGap [
 	self assert: (shapes collect: #position) asArray equals: withGap
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testBasicWithTopGap [
 	| withNoGap withGap |
 	RSTreeLayout new topGap: 15; on: canvas nodes.
@@ -65,13 +66,13 @@ RSTreeLayoutTest >> testBasicWithTopGap [
 	self assert: (shapes collect: #position) asArray equals: withGap
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testBasicWithVerticalGap [
 	RSTreeLayout new verticalGap: 50; on: canvas nodes.
 	self assert: (shapes collect: #position) asArray equals: {(23.5@7.5). (15.5@62.5). (35.5@62.5). (11.5@117.5). (23.5@117.5). (31.5@117.5). (39.5@117.5). (7.5@172.5). (15.5@172.5). (23.5@172.5)}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testDoNotValidateCyclesLayoutsEachShapeProperly [
 	| groups |
 	self computeTreeWithCycles.
@@ -84,13 +85,13 @@ RSTreeLayoutTest >> testDoNotValidateCyclesLayoutsEachShapeProperly [
 	self assert: groups size equals: shapes size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testDoNotValidateCyclesRunsNormally [
 	self computeTreeWithCycles.
 	RSTreeLayout new doNotValidateCycles; on: shapes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSTreeLayoutTest >> testValidateCyclesRaisesError [
 	self computeTreeWithCycles.
 	self should: [ RSTreeLayout new validateCycles on: shapes ] raise: Error

--- a/src/Roassal-Layouts-Tests/RSTreeLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSTreeLayoutTest.class.st
@@ -5,35 +5,10 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : 'tests' }
-RSTreeLayoutTest >> computeTreeWithCycles [
-	| chars |
-	canvas := RSLayoutNode new.
-	chars := $a to: $e.
-	shapes := RSLayoutNode models: chars forEach: [ :composite :char |
-		| box label |
-		label := RSLayoutNode text: char.
-		box := RSLayoutNode new
-			position: label position;
-			extent: label extent + 10;
-			yourself.
+{ #category : 'utilities' }
+RSTreeLayoutTest >> apply [
 
-		composite
-			draggable;
-			add: box;
-			add: label;
-			yourself.
-		].
-
-	canvas addAll: shapes.
-	RSLayoutLineBuilder new
-		canvas: canvas;
-		useAssociations:
-			{$a -> $b.
-			$a -> $e.
-			$b -> $c.
-			$c -> $d.
-			$d -> $a}. "cycle"
+	RSTreeLayout on: canvas nodes
 ]
 
 { #category : 'tests' }
@@ -75,7 +50,7 @@ RSTreeLayoutTest >> testBasicWithVerticalGap [
 { #category : 'tests' }
 RSTreeLayoutTest >> testDoNotValidateCyclesLayoutsEachShapeProperly [
 	| groups |
-	self computeTreeWithCycles.
+	self setUpGraphWithCycles.
 	RSTreeLayout new
 		horizontalGap: 10;
 		childrenSortBlock: [ :a :b | a model < b model ];
@@ -87,12 +62,12 @@ RSTreeLayoutTest >> testDoNotValidateCyclesLayoutsEachShapeProperly [
 
 { #category : 'tests' }
 RSTreeLayoutTest >> testDoNotValidateCyclesRunsNormally [
-	self computeTreeWithCycles.
+	self setUpGraphWithCycles.
 	RSTreeLayout new doNotValidateCycles; on: shapes
 ]
 
 { #category : 'tests' }
 RSTreeLayoutTest >> testValidateCyclesRaisesError [
-	self computeTreeWithCycles.
+	self setUpGraphWithCycles.
 	self should: [ RSTreeLayout new validateCycles on: shapes ] raise: Error
 ]

--- a/src/Roassal-Layouts-Tests/RSVerticalGridLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSVerticalGridLayoutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #RSVerticalGridLayoutTest,
-	#superclass : #RSLayoutTest,
-	#category : 'Roassal-Layouts-Tests'
+	#name : 'RSVerticalGridLayoutTest',
+	#superclass : 'RSLayoutTest',
+	#category : 'Roassal-Layouts-Tests',
+	#package : 'Roassal-Layouts-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSVerticalGridLayoutTest >> testBasic [
 
 	RSVerticalCellLayout on: canvas nodes.

--- a/src/Roassal-Layouts-Tests/RSVerticalGridLayoutTest.class.st
+++ b/src/Roassal-Layouts-Tests/RSVerticalGridLayoutTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'Roassal-Layouts-Tests'
 }
 
+{ #category : 'utilities' }
+RSVerticalGridLayoutTest >> apply [
+
+	RSVerticalCellLayout on: canvas nodes
+]
+
 { #category : 'tests' }
 RSVerticalGridLayoutTest >> testBasic [
 

--- a/src/Roassal-Layouts-Tests/package.st
+++ b/src/Roassal-Layouts-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Roassal-Layouts-Tests' }
+Package { #name : 'Roassal-Layouts-Tests' }

--- a/src/Roassal-Layouts/RSAbstractGraphLayout.class.st
+++ b/src/Roassal-Layouts/RSAbstractGraphLayout.class.st
@@ -115,6 +115,14 @@ RSAbstractGraphLayout >> childrenWithHighestNestingLevelFor: aNode [
 ]
 
 { #category : 'private' }
+RSAbstractGraphLayout >> childrenWithHighestNestingLevelFor: aNode except: aNodeCollection [
+
+	^ (self childrenFor: aNode) select: [ :eachChild |
+			  (aNodeCollection includes: eachChild) not and: [
+				  (self highestNestingParentFor: eachChild) == aNode ] ]
+]
+
+{ #category : 'private' }
 RSAbstractGraphLayout >> clear [
 	cachedParents := nil.
 	cachedChildren := nil.
@@ -140,15 +148,19 @@ RSAbstractGraphLayout >> doNotValidateCycles [
 
 { #category : 'private' }
 RSAbstractGraphLayout >> highestNestingParentFor: aNodeFigure [
+
 	| parents |
-	^self cachedParentsWithHighestNestings
-		at: aNodeFigure
-		ifAbsentPut:
-			[parents := self parentsFor: aNodeFigure.
-			parents isEmpty
-				ifTrue: [0]
-				ifFalse:
-					[parents detectMax: [:eachParent | self nestingLevelFor: eachParent]]]
+	^ self cachedParentsWithHighestNestings
+		  at: aNodeFigure
+		  ifAbsentPut: [
+				  parents := self parentsFor: aNodeFigure.
+				  parents isEmpty
+					  ifTrue: [ 0 ]
+					  ifFalse: [
+							  parents detectMax: [ :eachParent |
+									  self
+										  nestingLevelFor: eachParent
+										  whileProcessing: (IdentitySet with: aNodeFigure) ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -185,14 +197,19 @@ RSAbstractGraphLayout >> maximumRadius: aCollection [
 ]
 
 { #category : 'private' }
-RSAbstractGraphLayout >> nestingLevelFor: aNodeFigure [
-	| parents parentsNesting |
+RSAbstractGraphLayout >> nestingLevelFor: aNodeFigure whileProcessing: aCollectionOfChildren [
+
+	| parents parentsNesting childrenWithNodeFigure |
+	(aCollectionOfChildren includes: aNodeFigure) ifTrue: [ ^ 0 ]. "infinite loop check"
 	parents := self parentsFor: aNodeFigure.
-	parentsNesting := parents
-		collect: [:eachParent | self nestingLevelFor: eachParent].
-	^parentsNesting isEmpty
-		ifTrue: [0]
-		ifFalse: [parentsNesting max + 1]
+	childrenWithNodeFigure := aCollectionOfChildren copyWith: aNodeFigure.
+	parentsNesting := parents collect: [ :eachParent |
+			                  self
+				                  nestingLevelFor: eachParent
+				                  whileProcessing: childrenWithNodeFigure ].
+	^ parentsNesting isEmpty
+		  ifTrue: [ 0 ]
+		  ifFalse: [ parentsNesting max + 1 ]
 ]
 
 { #category : 'hook' }

--- a/src/Roassal-Layouts/RSAbstractVerticalTreeLayout.class.st
+++ b/src/Roassal-Layouts/RSAbstractVerticalTreeLayout.class.st
@@ -25,6 +25,7 @@ RSAbstractVerticalTreeLayout >> initialize [
 
 { #category : 'private - hook' }
 RSAbstractVerticalTreeLayout >> layout: aNodeCollection atPoint: aPoint atLayer: aNumber [
+
 	| treeSize childrenPosition x y middleOfTree |
 	aNodeCollection isEmpty ifTrue: [ ^ 0 ].
 	x := aPoint x.
@@ -32,22 +33,23 @@ RSAbstractVerticalTreeLayout >> layout: aNodeCollection atPoint: aPoint atLayer:
 	alreadyLayoutedNodes addAll: aNodeCollection.
 	self atLayer: aNumber add: aNodeCollection.
 	aNodeCollection do: [ :each |
-		| children |
-
-		childrenPosition := y + each height + self verticalGap.
-		children := self computeChildrenFor: each.
-
-		treeSize := self
-			layout: children
-			atPoint: x @ childrenPosition
-			atLayer: aNumber + 1.
-		treeSize < each width ifTrue: [
-			self translate: children by: (each width - treeSize) / 2.0 @ 0.
-			treeSize := each width. ].
-		middleOfTree := x + (treeSize / 2.0) - (each width / 2.0).
-		translator translateTopLeftOf: each to: middleOfTree @ y.
-		x := x + treeSize + self horizontalGap.
-		self step ].
+			| children |
+			childrenPosition := y + each height + self verticalGap.
+			children := self computeChildrenFor: each.
+			treeSize := self
+				            layout: children
+				            atPoint: x @ childrenPosition
+				            atLayer: aNumber + 1.
+			treeSize < each width ifTrue: [
+					self
+						translate: children
+						below: (Set with: each)
+						by: each width - treeSize / 2.0 @ 0.
+					treeSize := each width ].
+			middleOfTree := x + (treeSize / 2.0) - (each width / 2.0).
+			translator translateTopLeftOf: each to: middleOfTree @ y.
+			x := x + treeSize + self horizontalGap.
+			self step ].
 	^ x - aPoint x - self horizontalGap
 ]
 
@@ -63,9 +65,13 @@ RSAbstractVerticalTreeLayout >> rearrangeByLayers: aGraph [
 ]
 
 { #category : 'private - hook' }
-RSAbstractVerticalTreeLayout >> translate: aNodeCollection by: delta [
+RSAbstractVerticalTreeLayout >> translate: aNodeCollection below: aSetOfParents by: delta [
+
 	aNodeCollection ifEmpty: [ ^ self ].
 	aNodeCollection do: [ :each |
-		each translateBy: delta.
-		self translate: (self childrenFor: each) by: delta]
+			each translateBy: delta.
+			self
+				translate: (self childrenFor: each) \ aSetOfParents
+				below: (aSetOfParents copyWith: each)
+				by: delta ]
 ]

--- a/src/Roassal-Layouts/RSDominanceTreeLayout.class.st
+++ b/src/Roassal-Layouts/RSDominanceTreeLayout.class.st
@@ -11,5 +11,8 @@ Class {
 
 { #category : 'private - hook' }
 RSDominanceTreeLayout >> computeChildrenFor: aNode [
-	^ self childrenWithHighestNestingLevelFor: aNode
+
+	^ self
+		  childrenWithHighestNestingLevelFor: aNode
+		  except: alreadyLayoutedNodes
 ]

--- a/src/Roassal-Layouts/RSHorizontalDominanceTreeLayout.class.st
+++ b/src/Roassal-Layouts/RSHorizontalDominanceTreeLayout.class.st
@@ -11,5 +11,8 @@ Class {
 
 { #category : 'private - hook' }
 RSHorizontalDominanceTreeLayout >> computeChildrenFor: aNode [
-	^ self childrenWithHighestNestingLevelFor: aNode
+
+	^ self
+		  childrenWithHighestNestingLevelFor: aNode
+		  except: alreadyLayoutedNodes
 ]


### PR DESCRIPTION
* Fixed 3 sources of infinite loops when non-trees are being layouted as trees
  * fixes https://github.com/pharo-graphics/RoassalLayouts/issues/1 
  * fixes https://github.com/pharo-graphics/Roassal/issues/82
  * added tests for those cases
* Converted all files to Tonel v3.0
* Added Pharo 13 and 14 to CI and readme
* Updated CI depedencies to ones compatible with Pharo 13/14 and generally more recent

The problem of those inifinite loops were that few unrelated parts of tree-based layouts did not expect to get loops in the graph and ended up with an infinite recursion. This PR adds history to such recursive calls and checks for present of current nodes in this history. As a results, this makes nodes in a loop to display on a single level. This is far from ideal, but still better to have an ugly layout than an ongoing infinite loop. Maybe this could be improved, but I am unable to do that now. To prevent applying tree layouts for non-trees (thus making such ugly trees), there is still the `validateCycles` method.